### PR TITLE
feat: Profile skills association

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -5,6 +5,7 @@ const bodyParser = require("body-parser");
 const userRoutes = require("./server/routes/UserRoutes");
 const profileRoutes = require("./server/routes/ProfileRoutes");
 const specialtyRoutes = require("./server/routes/SpecialtyRoutes");
+const skillRoutes = require("./server/routes/SkillRoutes");
 
 
 config.config();
@@ -21,6 +22,7 @@ const port = process.env.PORT || 8000;
 app.use("/api/user", userRoutes);
 app.use("/api/profile", profileRoutes);
 app.use("/api/specialty", specialtyRoutes);
+app.use("/api/skill", skillRoutes);
 
 // when a random route is inputed
 app.get("*", (req, res) =>

--- a/api/server/controllers/ProfileController.js
+++ b/api/server/controllers/ProfileController.js
@@ -18,6 +18,11 @@ class ProfileController {
           const specialties = req.body.specialties;
           specialties.map(async s => await createdProfile.addSpecialty(s.id));
         }
+        if (req.body.skills) {
+          const skills = req.body.skills;
+          skills.map(async s => await createdProfile.addSkill(s.id));
+        }
+
         utils.setSuccess(201, "Profile Created!", createdProfile);
         return utils.send(res);
       } catch (error) {

--- a/api/server/controllers/SkillController.js
+++ b/api/server/controllers/SkillController.js
@@ -1,0 +1,87 @@
+const DBService = require("../services/DBService");
+const Util = require("../utils/Utils");
+const utils = new Util();
+
+class SkillController {
+  static async addSkill(req, res) {
+    if (req.body.description) {
+      const newSkill = req.body;
+      try {
+        const createdSkill = await DBService.create("Skill", newSkill)
+        utils.setSuccess(201, "Skill Created!", createdSkill);
+        return utils.send(res);
+      } catch (error) {
+        utils.setError(400, error.message);
+        return utils.send(res);
+      }
+    } else {
+      utils.setError(400, "Please provide complete details");
+      return utils.send(res);
+    }
+  }
+  static async getSkill(req, res) {
+    const { id } = req.params;
+    try {
+      const skill = await DBService.get("Skill", id);
+      if (!skill) {
+        utils.setError(404, `Cannot find skill`);
+      } else {
+        utils.setSuccess(200, "Found Skill", skill);
+      }
+      return utils.send(res);
+    } catch (error) {
+      utils.setError(404, error.message);
+      return utils.send(res);
+    }
+  }
+  static async getAllSkills(req, res) {
+    try {
+      const allSkills = await DBService.getAll("Skill");
+      if (allSkills.length > 0) {
+        utils.setSuccess(200, "Skills retrieved", allSkills);
+      } else {
+        utils.setSuccess(200, "No skills found", []);
+      }
+      return utils.send(res);
+    } catch (error) {
+      utils.setError(400, error.message);
+      return utils.send(res);
+    }
+  }
+  static async updateSkill(req, res) {
+    const alteredSkill = req.body;
+    const { id } = req.params;
+    try {
+      const updatedSkill = await DBService.update("Skill",
+        id,
+        alteredSkill
+      );
+      if (!updatedSkill) {
+        utils.setError(404, `Cannot find skill with the id: ${id}`);
+      } else {
+        utils.setSuccess(200, "skill updated", updatedSkill);
+      }
+      return utils.send(res);
+    } catch (error) {
+      utils.setError(404, error.message);
+      return utils.send(res);
+    }
+  }
+  static async deleteSkill(req, res) {
+    const { id } = req.params;
+    try {
+      const skillToDelete = await DBService.delete("Skill", id);
+      if (skillToDelete) {
+        utils.setSuccess(200, "Skill deleted");
+      } else {
+        utils.setError(404, `Skill with the id ${id} cannot be found`);
+      }
+      return utils.send(res);
+    } catch (error) {
+      utils.setError(400, error.message);
+      return utils.send(res);
+    }
+  }
+}
+
+module.exports = SkillController;

--- a/api/server/controllers/SpecialtyController.js
+++ b/api/server/controllers/SpecialtyController.js
@@ -48,7 +48,7 @@ class SpecialtyController {
       return utils.send(res);
     }
   }
-  static async udpateSpecialty(req, res) {
+  static async updateSpecialty(req, res) {
     const alteredSpecialty = req.body;
     const { id } = req.params;
     try {

--- a/api/server/migrations/20191220133609-create-skill-table.js
+++ b/api/server/migrations/20191220133609-create-skill-table.js
@@ -1,0 +1,30 @@
+const uuid = require("uuid/v4");
+("use strict");
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable("Skills", {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal("uuid_generate_v4()")
+      },
+      description: {
+        allowNull: false,
+        type: Sequelize.STRING
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable("Skills");
+  }
+};

--- a/api/server/migrations/20191220165546-create-profile-skill-join-table.js
+++ b/api/server/migrations/20191220165546-create-profile-skill-join-table.js
@@ -1,0 +1,42 @@
+const uuid = require("uuid/v4");
+("use strict");
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+      return queryInterface.createTable("Profile_Skills", {
+        id: {
+          allowNull: false,
+          primaryKey: true,
+          type: Sequelize.UUID,
+          defaultValue: Sequelize.literal("uuid_generate_v4()")
+        },
+        ProfileId: {
+          type: Sequelize.UUID,
+          references: {
+            model: "Profiles",
+            key: "id"
+          },
+          onDelete: 'cascade'
+        },
+        SkillId: {
+          type: Sequelize.UUID,
+          references: {
+            model: "Skills",
+            key: "id"
+          },
+          onDelete: 'cascade'
+        },
+        createdAt: {
+          allowNull: false,
+          type: Sequelize.DATE
+        },
+        updatedAt: {
+          allowNull: false,
+          type: Sequelize.DATE
+        }
+      });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable("Profile_Skills");
+  }
+};

--- a/api/server/models/Profile.js
+++ b/api/server/models/Profile.js
@@ -18,18 +18,28 @@ module.exports = (sequelize, DataTypes) => {
       UserId: {
         type: DataTypes.UUID,
         references: {
-          model: 'Users', 
-          key: 'id'
-       }
-  }
+          model: "Users",
+          key: "id"
+        }
+      }
     },
     {}
   );
-  // TODO: We still need to add profile type (frontend, backend, qa)
 
   Profile.associate = models => {
-    Profile.hasOne(models.User, { foreignKey: 'ProfileId', as: "user"  })
-    Profile.belongsToMany(models.Specialty, { as: 'specialty', through: 'Profile_Specialties', foreignKey: 'ProfileId',  otherKey: 'SpecialtyId' })
+    Profile.hasOne(models.User, { foreignKey: "ProfileId", as: "user" });
+    Profile.belongsToMany(models.Specialty, {
+      as: "specialty",
+      through: "Profile_Specialties",
+      foreignKey: "ProfileId",
+      otherKey: "SpecialtyId"
+    });
+    Profile.belongsToMany(models.Skill, {
+      as: "skill",
+      through: "Profile_Skills",
+      foreignKey: "ProfileId",
+      otherKey: "SkillId"
+    });
   };
 
   return Profile;

--- a/api/server/models/Skill.js
+++ b/api/server/models/Skill.js
@@ -1,0 +1,24 @@
+"use strict";
+const uuid = require("uuid/v4");
+
+module.exports = (sequelize, DataTypes) => {
+  const Skill = sequelize.define(
+    "Skill",
+    {
+      id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        primaryKey: true,
+        defaultValue: uuid()
+      },
+      description: DataTypes.STRING
+    },
+    {}
+  );
+
+  Skill.associate = models => {
+    Skill.belongsToMany(models.Profile, { as: 'profile', through: 'Profile_Skills', foreignKey: 'SkillId',  otherKey: 'ProfileId' })
+  };
+
+  return Skill;
+};

--- a/api/server/routes/SkillRoutes.js
+++ b/api/server/routes/SkillRoutes.js
@@ -1,0 +1,12 @@
+const express = require("express");
+const SkillController = require("../controllers/SkillController");
+
+const router = express.Router();
+
+router.post("/", SkillController.addSkill);
+router.get("/:id", SkillController.getSkill);
+router.get("/", SkillController.getAllSkills);
+router.put("/:id", SkillController.updateSkill);
+router.delete("/:id", SkillController.deleteSkill);
+
+module.exports = router;

--- a/api/server/routes/SpecialtyRoutes.js
+++ b/api/server/routes/SpecialtyRoutes.js
@@ -6,7 +6,7 @@ const router = express.Router();
 router.post("/", SpecialtyController.addSpecialty);
 router.get("/:id", SpecialtyController.getSpecialty);
 router.get("/", SpecialtyController.getAllSpecialties);
-router.put("/:id", SpecialtyController.udpateSpecialty);
+router.put("/:id", SpecialtyController.updateSpecialty);
 router.delete("/:id", SpecialtyController.deleteSpecialty);
 
 module.exports = router;

--- a/api/server/seeders/20191220161144-bulk-insert-skills.js
+++ b/api/server/seeders/20191220161144-bulk-insert-skills.js
@@ -1,0 +1,1062 @@
+"use strict";
+const uuidv4 = require('uuid/v4');
+
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    /*
+      Add altering commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.bulkInsert('People', [{
+        name: 'John Doe',
+        isBetaMember: false
+      }], {});
+    */
+   return queryInterface.bulkInsert(
+    "Skills",
+    [{
+      id: uuidv4(),
+      description: "3D Modeling",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "3Ds Max",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "AJAX",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "AWS (Amazon Web Services)",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Akka",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Android",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Angular",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Ansible",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Apache",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Architecture",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Awk",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Azure",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "BSD Unix",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Balsamiq",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Bash",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Big Data",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Blender",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Blockchain",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Bootstrap",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "C",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "C#",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "C++",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "CSS",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "CSS Grids",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "CakePHP",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Chef",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Clojure",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Clusto",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Cocoa",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Coffeescript",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "CosmosDB",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Cryptocurrency",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Cryptography",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Cucumber",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "D3.js",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Data Science",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Data Visualization",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Datomic",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Design",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "DevOps",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Django",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Docker",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Dojo",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Drupal",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "ES6",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Elixir",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Ember.js",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "F#",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Firebase",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Firmware",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Flash",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Flask",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Flexbox",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "GPS Sensors",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Game Design",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Gameplay",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Google Cloud",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Grails",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "GraphQL",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Groovy",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Gulp",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "HAML",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "HTML",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Hack",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Hadoop",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Haskell",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Hive",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "IBM Cloud",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "InDesign",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "InVision",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "J2EE",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "JQuery",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "JSON",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Jade",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Java",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "JavaScript",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Jenkins",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Jinja2",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Kafka",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Keras",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Kotlin",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "LAMP",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Laravel",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Linux / Unix",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Load Testing",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Lua",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "MATLAB",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Malware",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "MariaDB",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Maven",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Maya",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Microservices",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Mithrill.js",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "MongoDB",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "MySQL",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Networking",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Node",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "NoSQL",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Numpy",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "OmniGraffle",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "OpenAI",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "OpenEdge",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "OpenGL",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Oracle",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "PHP",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Perl",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Photoshop",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Pip",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Polymer",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "PostgreSQL",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Powershell",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Prototyping",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Puppet",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Python",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "R",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Radar",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Redis",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Redshift",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "React.js",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Redux.js",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Require.js",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Robotics",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Rust",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "SASS",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "SQL",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "SQLite",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "SSIS",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Scala",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Security",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Sensors",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Sharepoint",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Silverlight",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Smalltalk",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Smart Home",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Socket",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Sonar",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Spark",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Sphinx",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Spring",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Stapes.js",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Struts",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Stylesheets",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Swift",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Swing",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Tableau",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "TechOps",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "TerraForm",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Travis",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "UI Design",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "UX Design",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "UX Research",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Unity",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Usability",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "VMware",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Wakewords",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Watir",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Watson",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Wearables",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Windows",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "XML",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Xamarin",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "Yii",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "backbone.js",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "coffescript",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "express.js",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "grunt",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "jasmine",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "knockout",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "scipy",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "three.js",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    },
+    {
+      id: uuidv4(),
+      description: "vue.js",
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }],
+    {}
+  );
+  },
+
+  down: (queryInterface, Sequelize) => {
+    /*
+      Add reverting commands here.
+      Return a promise to correctly handle asynchronicity.
+
+      Example:
+      return queryInterface.bulkDelete('People', null, {});
+    */
+   return queryInterface.bulkDelete("Skills", null, {});
+  }
+};
+
+
+

--- a/api/server/services/DBService.js
+++ b/api/server/services/DBService.js
@@ -1,0 +1,60 @@
+const database = require("../models");
+
+class DBService {
+  static async create(model, newInstance) {
+    try {
+      return await database[model].create(newInstance);
+    } catch (error) {
+      throw error;
+    }
+  }
+  static async get(model, id) {
+    try {
+      const instance = await database[model].findOne({
+        where: { id: id }
+      });
+      return instance;
+    } catch (error) {
+      throw error;
+    }
+  }
+  static async getAll(model) {
+    try {
+      return await database[model].findAll();
+    } catch (error) {
+      throw error;
+    }
+  }
+  static async update(model, id, updatedInstance) {
+    try {
+      const instanceToUpdate = await database[model].findOne({
+        where: { id: id },
+      });
+      if (instanceToUpdate) {
+        await database[model].update(updatedInstance, { where: { id: id } });
+        return updatedInstance;
+      }
+      return null;
+    } catch (error) {
+      throw error;
+    }
+  }
+  static async delete(model, id) {
+    try {
+      const instanceToDelete = await database[model].findOne({
+        where: { id: id }
+      });
+      if (instanceToDelete) {
+        const deletedInstance = await database[model].destroy({
+          where: { id: id }
+        });
+        return deletedInstance;
+      }
+      return null;
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+
+module.exports = DBService;

--- a/api/server/services/ProfileService.js
+++ b/api/server/services/ProfileService.js
@@ -18,6 +18,12 @@ class ProfileService {
             as: "specialty",
             attributes: ['id', 'description'],
             through: {attributes: []}
+          },
+          {
+            model: database.Skill,
+            as: "skill",
+            attributes: ['id', 'description'],
+            through: {attributes: []}
           }
         ]
       });

--- a/api/server/test/Profile.test.js
+++ b/api/server/test/Profile.test.js
@@ -74,8 +74,11 @@ describe("PROFILE", () => {
     // 2) Assign a new profile to the user
     it("should create a new profile in the DB with new user id", done => {
       const newProfile = Object.assign({}, MOCKS.PROFILE, {
-        specialties: MOCKS.SPECIALTIES
+        specialties: MOCKS.SPECIALTIES,
+        skills: MOCKS.SKILLS
       });
+      console.log("*********************NEW PROFILE***************************", newProfile)
+      
       chai
         .request(server)
         .post(profileRoute)
@@ -158,6 +161,17 @@ describe("PROFILE", () => {
             const mockedSpecialty = MOCKS.SPECIALTIES[i];
             expect(s.id).to.equal(mockedSpecialty.id);
             expect(s.description).to.equal(mockedSpecialty.description);
+          });
+          
+          // Validate profile SKILLS
+          expect(res.body.data.skill).to.be.a("array");
+          expect(res.body.data.skill[0]).to.be.a("object");
+          expect(res.body.data.skill[0]).to.have.property("id");
+          expect(res.body.data.skill[0]).to.have.property("description");
+          res.body.data.skill.map((s, i) => {
+            const mockedSkill = MOCKS.SKILLS[i];
+            expect(s.id).to.equal(mockedSkill.id);
+            expect(s.description).to.equal(mockedSkill.description);
           });
 
           done();

--- a/api/server/test/Skill.test.js
+++ b/api/server/test/Skill.test.js
@@ -1,0 +1,180 @@
+const chai = require("chai");
+const chaiHttp = require("chai-http");
+
+const { expect } = chai;
+
+const server = require("../../index");
+const { cleanDB } = require("./utils/helpers");
+const { MOCKS, PROPS, FAKE_ID } = require("./utils/constants");
+
+const skillRoute = "/api/skill";
+
+chai.use(chaiHttp);
+
+describe("SKILL", () => {
+  let skillCreatedByPOST = {};
+
+  before(async () => {
+    await cleanDB();
+  });
+
+  /*
+   * Test the /GET default
+   */
+  describe("\n ----- GET / default msg -------------------------\n", () => {
+    it("should show welcome message", done => {
+      chai
+        .request(server)
+        .get("/")
+        .end((err, res) => {
+          expect(res).to.have.status(200);
+          expect(res.body.message).to.equals("Welcome to this API.");
+          done();
+        });
+    });
+  });
+
+  /*
+   * Test the /GET all skills
+   */
+  describe("\n ----- GET /skill ------------------------------\n", () => {
+    it("should return an array of skills", done => {
+      chai
+        .request(server)
+        .get(skillRoute)
+        .end(function(err, res) {
+          expect(res).to.have.status(200);
+          expect(res.body.data).to.be.a("array");
+          expect(res.body.data).to.have.lengthOf(171);
+          done();
+        });
+    });
+  });
+
+  /*
+   * Test the /POST skill
+   */
+  describe("\n ----- POST /skill ------------------------------\n", () => {
+    it("should create a new skill in the DB", done => {
+      const description = "Test Skill";
+      chai
+        .request(server)
+        .post(skillRoute)
+        .send({ description })
+        .end((err, res) => {
+          expect(res).to.have.status(201);
+          expect(res.body.status).to.equal("success");
+
+          expect(res.body.data).to.be.a("object");
+          for (let i = 0; i < PROPS.SKILL.length; i++) {
+            expect(res.body.data).to.have.property(PROPS.SKILL[i]);
+          }
+
+          expect(res.body.data.description).to.equal(description);
+
+          skillCreatedByPOST = Object.assign({}, res.body.data);
+
+          done();
+        });
+    });
+  });
+
+  /*
+   * Test the /GET specific skill
+   */
+  describe("\n----- GET /skill/:id ------------------------------\n", () => {
+    it("should return 404 because skill doesn't exist", done => {
+      chai
+        .request(server)
+        .get(`${skillRoute}/${FAKE_ID.SKILL}`)
+        .end(function(err, res) {
+          expect(res).to.have.status(404);
+          expect(res.body.status).to.equal("error");
+          done();
+        });
+    });
+    it("should return a specific skill", done => {
+      chai
+        .request(server)
+        .get(`${skillRoute}/${MOCKS.SKILLS[0].id}`)
+        .end(function(err, res) {
+          expect(res).to.have.status(200);
+          expect(res.body.status).to.equal("success");
+
+          expect(res.body.data).to.be.a("object");
+          for (let i = 0; i < PROPS.SKILL.length; i++) {
+            expect(res.body.data).to.have.property(PROPS.SKILL[i]);
+          }
+          
+          expect(res.body.data.id).to.equal(MOCKS.SKILLS[0].id);
+          expect(res.body.data.description).to.equal(
+            MOCKS.SKILLS[0].description
+          );
+
+          done();
+        });
+    });
+  });
+  /*
+   * Test the /PUT skill
+   * Will update the skill created by POST above
+   */
+  describe("\n----- PUT /skill/:id ------------------------------\n", () => {
+    it("should return 404 because skill doesn't exist", done => {
+      chai
+        .request(server)
+        .put(`${skillRoute}/${FAKE_ID.SKILL}`)
+        .send({ description: "New test description" })
+        .end(function(err, res) {
+          expect(res).to.have.status(404);
+          expect(res.body.status).to.equal("error");
+          done();
+        });
+    });
+    it("should return the skill updated", done => {
+      const description = "Skill Updated";
+      chai
+        .request(server)
+        .put(`${skillRoute}/${skillCreatedByPOST.id}`)
+        .send({ description })
+        .end(function(err, res) {
+          expect(res).to.have.status(200);
+          expect(res.body.status).to.equal("success");
+
+          expect(res.body.data).to.be.a("object");
+
+          expect(res.body.data).to.have.property("description");
+
+          expect(res.body.data.description).to.equal(description);
+
+          done();
+        });
+    });
+  });
+  /*
+   * Test the /DELETE skill
+   * Will delete the skill created by POST above
+   */
+  describe("\n----- DELETE /skill/:id ------------------------------\n", () => {
+    it("should return 404 because skill doesn't exist", done => {
+      chai
+        .request(server)
+        .delete(`${skillRoute}/${FAKE_ID.SKILL}`)
+        .end(function(err, res) {
+          expect(res).to.have.status(404);
+          expect(res.body.status).to.equal("error");
+          done();
+        });
+    });
+    it("should delete the skill created by POST", done => {
+      chai
+        .request(server)
+        .delete(`${skillRoute}/${skillCreatedByPOST.id}`)
+        .end(function(err, res) {
+          expect(res).to.have.status(200);
+          expect(res.body.status).to.equal("success");
+          done();
+        });
+    });
+  });
+});

--- a/api/server/test/utils/constants.js
+++ b/api/server/test/utils/constants.js
@@ -8,12 +8,18 @@ const MOCKS = {
     image_path: "https://avatars3.githubusercontent.com/u/3179348?s=460&v=4",
     linkedin: "https://www.linkedin.com/in/eleonora-lester-7a432022",
     github: "elstr",
-    twitter: "http://www.twitter.com/lele_lester",
+    twitter: "http://www.twitter.com/lele_lester"
   },
   SPECIALTIES: [
     { id: "d0cc0eea-6331-4c40-a75d-6a00e6911943", description: "Front End" },
     { id: "3acc04bb-be14-4d38-be4a-56709805b461", description: "Back End" },
     { id: "2ff867dc-3465-4af3-bc27-5a74d177b31a", description: "QA" }
+  ],
+  SKILLS: [
+    { id: "c7725624-6fb3-4a7f-9e6b-659d2a54592e", description: "Redis" },
+    { id: "fb7456a4-e25c-4e21-96e7-39ebd22cc02d", description: "Redshift" },
+    { id: "eef36f53-acf8-416a-95e6-58b3eb9f653d", description: "Redux.js" },
+    { id: "afb62a5e-8527-4cb8-966e-78edbdc94aac", description: "React.js" }
   ]
 };
 
@@ -39,18 +45,15 @@ const PROPS = {
     "createdAt",
     "updatedAt"
   ],
-  SPECIALTY: [
-    "id",
-    "description",
-    "createdAt",
-    "updatedAt"
-  ]
+  SPECIALTY: ["id", "description", "createdAt", "updatedAt"],
+  SKILL: ["id", "description", "createdAt", "updatedAt"]
 };
 
 const FAKE_ID = {
   USER: "5e016e8e-1804-4c35-abdd-9c0427989999",
   PROFILE: "da775875-5907-4f9e-a2bf-be9727c21bbf",
-  SPECIALTY: "d0cc0eea-6331-4c40-a75d-6a00e9999999"
+  SPECIALTY: "d0cc0eea-6331-4c40-a75d-6a00e9999999",
+  SKILL: "fb7456a4-e25c-4e21-96e7-39ebd22cc99d"
 };
 
 module.exports = {

--- a/api/server/test/utils/constants.js
+++ b/api/server/test/utils/constants.js
@@ -18,8 +18,8 @@ const MOCKS = {
   SKILLS: [
     { id: "c7725624-6fb3-4a7f-9e6b-659d2a54592e", description: "Redis" },
     { id: "fb7456a4-e25c-4e21-96e7-39ebd22cc02d", description: "Redshift" },
-    { id: "eef36f53-acf8-416a-95e6-58b3eb9f653d", description: "Redux.js" },
-    { id: "afb62a5e-8527-4cb8-966e-78edbdc94aac", description: "React.js" }
+    { id: "afb62a5e-8527-4cb8-966e-78edbdc94aac", description: "React.js" },
+    { id: "eef36f53-acf8-416a-95e6-58b3eb9f653d", description: "Redux.js" }
   ]
 };
 

--- a/api/server/test/utils/helpers.js
+++ b/api/server/test/utils/helpers.js
@@ -7,7 +7,7 @@ const models = require("../../models");
   * If other tables are being seeded with constant values, go ahead and add the models to the array,
     otherwise you should start with fresh empty tables for testing purposes.
 */
-const specialTables = ["sequelize", "Sequelize", "Specialty"];
+const specialTables = ["sequelize", "Sequelize", "Specialty", "Skill"];
 
 const cleanDB = async () => {
   return await Promise.all(

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "nodemon --exec babel-node ./api/index.js",
     "start": "node ./api/index.js",
+    "seed": "sequelize db:seed:all",
     "seed:testing": "NODE_ENV=testing sequelize db:seed:all",
+    "migrate": "sequelize db:migrate",
+    "migrate:testing": "NODE_ENV=testing sequelize db:migrate",
     "pretest": "NODE_ENV=testing sequelize db:migrate",
     "test": "npm run pretest && NODE_ENV=testing mocha './api/server/test/*.test.js' --timeout 10000",
     "cover": "nyc -x \"./node_modules/\" npm run test"


### PR DESCRIPTION
- Adds skills routes and logic
- Adds profile skills association
- Adds `DBService` to change architecture to use single service
- Adds tests for profile-skills association
- Adds skills tests
- Adds more npm scripts for seeding and migrations
- Fixes typo in `specialties` routes and controller