### PR TITLE
fix: User cascade delete profile

### DIFF
--- a/api/server/controllers/ProfileController.js
+++ b/api/server/controllers/ProfileController.js
@@ -11,7 +11,8 @@ class ProfileController {
         const createdProfile = await ProfileService.addProfile(newProfile);
         // once profile is created, update user to set ProfilId to the ID of the created profile
         await UserService.updateUser(newProfile.UserId, {
-          ProfileId: createdProfile.id
+          ProfileId: createdProfile.id,
+          completed_profile: true
         });
 
         if (req.body.specialties) {

--- a/api/server/migrations/20200121175222-fix-cascade-delete-user-in-profile.js
+++ b/api/server/migrations/20200121175222-fix-cascade-delete-user-in-profile.js
@@ -1,0 +1,19 @@
+"use strict";
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+   return queryInterface.changeColumn('Profiles', 'UserId', {
+      type: Sequelize.UUID,
+      references: {
+        model: "Users",
+        key: "id"
+      },
+      onUpdate: "CASCADE",
+      onDelete: "CASCADE"
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('Profiles', 'UserId');
+  }
+};

--- a/api/server/migrations/20200121192151-delete-profile-userid-contstraint.js
+++ b/api/server/migrations/20200121192151-delete-profile-userid-contstraint.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn("Profiles", "UserId");
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn("Profiles", "UserId", {
+      type: Sequelize.UUID,
+      references: {
+        model: "Users",
+        key: "id"
+      },
+      onUpdate: "CASCADE",
+      onDelete: "CASCADE"
+    });
+  }
+};

--- a/api/server/migrations/20200121192628-set-cascade-profile-user.js
+++ b/api/server/migrations/20200121192628-set-cascade-profile-user.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn("Profiles", "UserId", {
+      type: Sequelize.UUID,
+      references: {
+        model: "Users",
+        key: "id"
+      },
+      onUpdate: "CASCADE",
+      onDelete: "CASCADE"
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn("Profiles", "UserId");
+  }
+};

--- a/api/server/models/Profile.js
+++ b/api/server/models/Profile.js
@@ -27,7 +27,10 @@ module.exports = (sequelize, DataTypes) => {
   );
 
   Profile.associate = models => {
-    Profile.hasOne(models.User, { foreignKey: "ProfileId", as: "user" });
+    Profile.hasOne(models.User, {
+      foreignKey: "ProfileId",
+      as: "user"
+    });
     Profile.belongsToMany(models.Specialty, {
       as: "specialty",
       through: "Profile_Specialties",

--- a/api/server/models/User.js
+++ b/api/server/models/User.js
@@ -28,7 +28,12 @@ module.exports = (sequelize, DataTypes) => {
   );
 
   User.associate = function(models) {
-    User.hasOne(models.Profile, { foreignKey: "UserId", as: "profile" });
+    User.hasOne(models.Profile, {
+      foreignKey: "UserId",
+      as: "profile",
+      onDelete: "cascade",
+      hooks: true
+    });
   };
 
   return User;


### PR DESCRIPTION
- @puribey  Test without running `sequelize db:migrate`  I'm not 100% the migrations are necessary if I specify in the model associations that we use `onDelete: cascade`

I can't re-check that bc I've already run the migrations.


Edit: After testing, migrations with cascade edition + model with `onDelete: cascade` are necessary. Both things are needed.