### PR TITLE
fix: delete created_profile field in user

### DIFF
--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -13,7 +13,6 @@ class UserController {
       if (!user) {
         const newUser = req.body;
         newUser.accepted_terms = false;
-        newUser.completed_profile = false;
         const createdUser = await UserService.addUser(newUser);
         utils.setSuccess(201, "User Added!", createdUser);
         return utils.send(res);

--- a/api/server/migrations/20200122155813-delete-complete-profile-in-user-table.js
+++ b/api/server/migrations/20200122155813-delete-complete-profile-in-user-table.js
@@ -1,0 +1,15 @@
+"use strict";
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn("Users", "completed_profile");
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn(
+      "Users",
+      "completed_profile",
+      Sequelize.BOOLEAN
+    );
+  }
+};

--- a/api/server/models/User.js
+++ b/api/server/models/User.js
@@ -15,7 +15,6 @@ module.exports = (sequelize, DataTypes) => {
       auth_sub: DataTypes.STRING,
       email: DataTypes.STRING,
       accepted_terms: DataTypes.BOOLEAN,
-      completed_profile: DataTypes.BOOLEAN,
       ProfileId: {
         type: DataTypes.UUID,
         references: {

--- a/api/server/test/User.test.js
+++ b/api/server/test/User.test.js
@@ -74,7 +74,6 @@ describe("USER", () => {
           expect(res.body.data.auth_sub).to.equal(MOCKS.USER.auth_sub);
           expect(res.body.data.email).to.equal(MOCKS.USER.email);
           expect(res.body.data.accepted_terms).to.equal(false);
-          expect(res.body.data.completed_profile).to.equal(false);
           expect(res.body.data.ProfileId).to.equal(null);
 
           userCreatedByPOST = Object.assign({}, res.body.data);

--- a/api/server/test/utils/constants.js
+++ b/api/server/test/utils/constants.js
@@ -30,7 +30,6 @@ const PROPS = {
     "auth_sub",
     "email",
     "accepted_terms",
-    "completed_profile",
     "ProfileId",
     "updatedAt",
     "createdAt"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "nodemon --exec babel-node ./api/index.js",
+    "dev": "NODE_ENV=development nodemon ./api/index.js",
     "start": "node ./api/index.js",
     "seed": "sequelize db:seed:all",
     "seed:testing": "NODE_ENV=testing sequelize db:seed:all",


### PR DESCRIPTION
Deletes `created_profile` boolean in table `users` because we now check for `profileId`.
If `profileId = null`  it's not necessary to specify `created_profile = false`.

@puribey frontend should be modified to reflect this change.